### PR TITLE
fix(ingestion/glossary): sync issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ jobs:
           # TODO(developer): Update this with your config/credentials.
           business_glossary_file: ./business_glossary.yml
           enable_auto_id: "true"
+          prune: "false"
 
           datahub_gms_host: https://<customer>.acryl.io/gms
           datahub_gms_token: ${{ secrets.ACRYL_GMS_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,9 @@ inputs:
   enable_auto_id:
     description: "Set to true if you use `enable_auto_id` in your business glossary ingestion."
     default: "false"
+  prune:
+    description: "Set to true if you want to use only glossraies from file and not the use from server"
+    default: "false"
 
   debug_mode:
     description: "Set to true to enable debug mode."
@@ -38,7 +41,8 @@ runs:
         python ${{ github.action_path }}/glossary-sync.py \
           update-glossary-file \
           --enable-auto-id ${{ inputs.enable_auto_id }} \
-          --file ${{ inputs.business_glossary_file }}
+          --file ${{ inputs.business_glossary_file }} \
+          --prune ${{ inputs.prune }}
 
         git status
       env:

--- a/glossary-sync.py
+++ b/glossary-sync.py
@@ -511,15 +511,16 @@ def cli():
 @cli.command()
 @click.option("--enable-auto-id", type=bool, required=True)
 @click.option("--file", type=click.Path(exists=True, dir_okay=False), required=True)
+@click.option("--prune", type=bool, default=False, required=False)
 @click.option("--output", type=click.Path())
 def update_glossary_file(
-    file: str, enable_auto_id: bool, output: Optional[str]
+    file: str, enable_auto_id: bool, prune: bool, output: Optional[str]
 ) -> None:
     if not output:
         output = file
 
     _update_glossary_file(
-        file, enable_auto_id=enable_auto_id, output=output, prune=True
+        file, enable_auto_id=enable_auto_id, output=output, prune=prune
     )
 
 


### PR DESCRIPTION
- added the option `@click.option("--prune", type=bool, default=False, required=False)` for `update_glossary_file method`
- made the `Prune = False` default, this will `merge` the glossary data from `server` and `file`