### PR TITLE
fix(deps): upgrade acryl-datahub to 1.3.0 for multiple ownership types support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-acryl-datahub[datahub-business-glossary]==0.14.1.12
+acryl-datahub[datahub-business-glossary]==1.3.0
 ruamel.yaml


### PR DESCRIPTION
## Description

Upgrades `acryl-datahub` from 0.14.1.12 to 1.3.0 to support multiple ownership types in business glossary configurations.

## Problem

Users were encountering a Pydantic validation error when syncing glossaries that contained multiple ownership types:

```
pydantic.error_wrappers.ValidationError: 1 validation error for GlossaryNodeConfig
owners
  value is not a valid dict (type=type_error.dict)
```

This occurred because DataHub allows multiple ownership types per glossary node/term, but the business glossary YAML format (prior to v0.15) only supported a single `Owners` object.

## Solution

The issue was fixed upstream in [datahub-project/datahub#12050](https://github.com/datahub-project/datahub/pull/12050) (merged Dec 2024), which added support for `owners: Union[Owners, List[Owners]]` in the YAML schema.

This PR bumps to the latest version (1.3.0) to include that fix and other improvements.

## Testing

- [x] Existing workflows continue to work
- [x] Glossaries with multiple ownership types now sync without validation errors